### PR TITLE
imagemagick is part of imagemagick

### DIFF
--- a/islandora_pdf.info.yml
+++ b/islandora_pdf.info.yml
@@ -2,7 +2,7 @@ name: 'Islandora PDF'
 description: 'A default Islandora Repository module to handle PDF files'
 dependencies:
   - :islandora
-  - drupal:imagemagick
+  - imagemagick:imagemagick
 package: 'Islandora Solution Packs'
 core: 8.x
 type: module


### PR DESCRIPTION
Fixes a requirement so the module will install more reliably.

# How should this be tested?

Attempt to install the module from its own directory and it will succeed after this fix.

